### PR TITLE
Added Data Validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 bentoml
 docker
+cerberus


### PR DESCRIPTION
Checking the Heroku config before running shell commands. If config is incorrect, throw an error and show the problem.
* Makes sure that `dyno_counts` are:
  * present
  * integer
  * more than 0
* Makes sure that `dyno_type` is:
  * present 
  * string
  * one of the [official dyno types](https://devcenter.heroku.com/articles/dyno-types#mixing-dyno-types)

```bash
~/Git/heroku-deploy$ python deploy.py /home/damir/bentoml/repository/IrisClassifier/20210923152106_C95F2E test-script heroku_config.json 
Traceback (most recent call last):
  File "deploy.py", line 47, in <module>
    deploy_heroku(bento_bundle_path, deployment_name, config_json)
  File "deploy.py", line 7, in deploy_heroku
    heroku_config = get_configuration_value(config_json)
  File "/home/damir/Git/heroku-deploy/utils/__init__.py", line 31, in get_configuration_value
    validate_configuration_value(configuration)
  File "/home/damir/Git/heroku-deploy/utils/__init__.py", line 70, in validate_configuration_value
    raise Exception(
Exception: Config validation failed {'dyno_counts': ['min value is 1']}
```
