### PR TITLE
Fix the installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This tool can be used as an Operator for the [bentoctl](https://github.com/bento
 
 1. Install bentoctl
     ```bash
-    $ pip install bentoctl
+    $ pip install --pre bentoctl
     ```
 
 2. Add Heroku operator


### PR DESCRIPTION
Currently, if I ran:
```bash
pip install bentoctl
```
I can't run the command `bentoctl`. Only when I ran:
```bash
pip install --pre bentoctl
```
that the command works